### PR TITLE
Relax connect ports for websocket apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER stefan.rinke@octomind.dev
 
 RUN apk update && apk add --no-cache wget jq apache2-utils squid curl
 WORKDIR /app
-ARG FRP_VERSION="0.60.0"
+ARG FRP_VERSION="0.61.1"
 RUN wget https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz -O /app/frp.tar.gz
 RUN tar xvzf /app/frp.tar.gz && mv -f frp_${FRP_VERSION}_linux_amd64 frp && rm /app/frp/frps && rm /app/frp.tar.gz
 COPY frpc /app/frp

--- a/squid.conf
+++ b/squid.conf
@@ -1530,7 +1530,7 @@ acl Safe_ports port 777         # multiling http
 http_access deny !Safe_ports
 
 # Deny CONNECT to other than secure SSL ports
-http_access deny CONNECT !SSL_ports
+http_access deny CONNECT !Safe_ports
 
 # Only allow cachemgr access from localhost
 http_access allow localhost manager
@@ -4878,6 +4878,7 @@ http_port 3128
 #       than would otherwise be kept by logfile_rotate.
 #       For most uses a single log should be enough to monitor current
 #       events affecting Squid.
+debug_options ALL,1
 #Default:
 # Log all critical and important messages.
 
@@ -9036,6 +9037,10 @@ refresh_pattern .               0       20%     4320
 #       acl UpgradeHeaderHasMultipleOffers ...
 #       http_upgrade_request_protocols Baz deny UpgradeHeaderHasMultipleOffers
 #       http_upgrade_request_protocols Baz allow all
+http_upgrade_request_protocols websocket allow all
+http_upgrade_request_protocols OTHER deny all
+
+# did not help on_unsupported_protocol tunnel all
 #Default:
 # Upgrade header dropped, effectively blocking an upgrade attempt.
 


### PR DESCRIPTION
- update frp client to 0.61.1
- connect is now allowed to all "Safe_Ports" (see squid.conf)