### PR TITLE
No pid and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 passwords
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ NYI: for scaling we will also support multiple instances of worker with the same
 ## run
 
 private location worker can simply run as docker container:
-```
+```sh
 docker run --rm -e PLW_NAME=worker1 -e APIKEY=12345 -e PROXY_PASS=secret -e PROXY_USER=octo eu.gcr.io/octomind-dev/plw:latest
 ```
 
@@ -105,4 +105,25 @@ spec:
     - name: PROXY_PASS
       value: secret11
 ```
+### podman
+
+As podman is build a *drop in* replacement for docker the private location worker can be used with podman as well:
+
+```sh
+podman run --rm -e PLW_NAME=worker1 -e APIKEY=12345 -e PROXY_PASS=secret -e PROXY_USER=octo eu.gcr.io/octomind-dev/plw:latest
+```
+
+### podman on windows
+
+If you run the private location worker with podman on windows be aware that the networking in wsl (windows subsystem for linux)
+behaves slightly different to podman on linux. E.g. if you want to connect to a service running on the same host as the
+private location worker, you need to configure your network see [here](https://stackoverflow.com/questions/79098571/podman-container-cannot-connect-to-windows-host) or [on github](https://github.com/eriksjolund/podman-networking-docs?tab=readme-ov-file#outbound-tcpudp-connections-to-the-hosts-localhost)
+
+For example if you want to access a service on the host machine on port 8080 you need to add:
+
+```sh
+podman run --rm ... --network=pasta:-T,8080:8080 eu.gcr.io/octomind-dev/plw:latest
+```
+
+but this only one option, see [github doc](https://github.com/eriksjolund/podman-networking-docs?tab=readme-ov-file#outbound-tcpudp-connections-to-the-hosts-localhost)
 

--- a/squid.conf
+++ b/squid.conf
@@ -4810,7 +4810,7 @@ http_port 3128
 #  TAG: pid_filename
 #       A filename to write the process-id to.  To disable, enter "none".
 #Default:
-# pid_filename /run/squid.pid
+pid_filename none
 
 #  TAG: client_netmask
 #       A netmask for client addresses in logfiles and cachemgr output.


### PR DESCRIPTION
changed config so that squid does write a pid file. when the container is not deleted a "fresh" pid file prevents a restart.

Also added some doc on the usage of podman and even more specific podman on windows with wsl, as this requires some tweaking in the network if the service to use runs on the host machine  