### PR TITLE
forwarded_for delete

### DIFF
--- a/squid.conf
+++ b/squid.conf
@@ -8656,6 +8656,8 @@ refresh_pattern .               0       20%     4320
 #       X-Forwarded-For entries, and place the client IP as the sole entry.
 #Default:
 # forwarded_for on
+# Don't allow headers that leak clients IP
+forwarded_for delete
 
 #  TAG: cachemgr_passwd
 #       Specify passwords for cachemgr operations.


### PR DESCRIPTION
Don't allow headers that leak clients IP: Don't set and delete any existing X-forwarded-for http headers.